### PR TITLE
add missing apt-get clean

### DIFF
--- a/node/9-chromium/Dockerfile
+++ b/node/9-chromium/Dockerfile
@@ -5,4 +5,5 @@ RUN apt-get update \
         chromium \
         libgtk-3-0 \
         libatk-bridge2.0-0 \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean

--- a/php/5/Dockerfile
+++ b/php/5/Dockerfile
@@ -9,5 +9,6 @@ RUN apt-get update \
         zip \
         unzip \
     && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
     && curl --silent --show-error https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer

--- a/php/7/Dockerfile
+++ b/php/7/Dockerfile
@@ -8,5 +8,7 @@ RUN apt-get update \
         git \
         zip \
         unzip \
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean \
     && curl --silent --show-error https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer


### PR DESCRIPTION
apt-get clean clears out the local repository of retrieved
package files.It removes everything but the lock file from
/var/cache/apt/archives/ and
/var/cache/apt/archives/partial/.