### PR TITLE
Add gd extension support to PHP images

### DIFF
--- a/php/5/Dockerfile
+++ b/php/5/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update \
         git \
         zip \
         unzip \
+	libpng-dev \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
     && curl --silent --show-error https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer
+RUN docker-php-ext-install gd

--- a/php/7/Dockerfile
+++ b/php/7/Dockerfile
@@ -8,7 +8,9 @@ RUN apt-get update \
         git \
         zip \
         unzip \
+	libpng-dev \
     && rm -rf /var/lib/apt/lists/* \
     && apt-get clean \
     && curl --silent --show-error https://getcomposer.org/installer | php \
     && mv composer.phar /usr/local/bin/composer
+RUN docker-php-ext-install gd


### PR DESCRIPTION
The [gd extension](http://php.net/manual/en/book.image.php) is required by [mpdf](https://github.com/mpdf/mpdf) to generate PDF documents.